### PR TITLE
Sugestão de melhoria

### DIFF
--- a/gerador-token.php
+++ b/gerador-token.php
@@ -1,34 +1,23 @@
 <?php
 
-$token = NULL; //Token indefinido.
-$digitos = 8; //Define quantos digitos o token possui.
-$flagError = false; //Controla a chamada da mensagem de erro.
-
-for($i=0;$i < $digitos;$i++){
-    $sensibilidade = rand(0,9); //Define a sensibilidade de alternar LETRA e NUMERO.
-
-    if(!$flagError){
-        if($sensibilidade < 3){
+function token($digitos)
+{
+    $token = "";
+    while (strlen($token) < $digitos) {
+        $sensibilidade = rand(0, 9); //Define a sensibilidade de alternar LETRA e NUMERO.
+        if ($sensibilidade < 3) {
             //Sorteia letras maiusculas.
-            $token .= chr(rand(65,90)); 
-
-        }else if($sensibilidade >= 3 && $sensibilidade <= 5){
+            $token .= chr(rand(65, 90));
+        } else if ($sensibilidade >= 3 && $sensibilidade <= 5) {
             //Sorteia letras minusculas.
-            $token .= chr(rand(97,122));
-
-        }else if($sensibilidade >= 6 && $sensibilidade <9){
+            $token .= chr(rand(97, 122));
+        } else if ($sensibilidade >= 6 && $sensibilidade < 9) {
             //Sorteia numeros de um único dígito.
-            $token .= rand(0,9);
-
-        } else {
-            //Divergência da faixa de sensibilidade e do valor gerado.
-            $token = "Erro: Verifique a faixa de sensibilidade";
-            $flagError = true;
+            $token .= rand(0, 9);
         }
     }
+    return $token;
 }
-
-echo $token."<br/>"; //Exibe o token.
+$token = token(8);
+echo $token . "<br/>"; //Exibe o token.
 echo strlen($token); //Confere o tamanho do token.
-
-?>


### PR DESCRIPTION
Boa noite, primeiramente parabéns pela iniciativa e pelo projeto.

Se você verificar se a quantidade de dígitos já foi alcançada e incrementar apenas se a sensibilidade é o que você quer, você não precisará mostrar ao usuário a mensagem: Erro: Verifique a faixa de sensibilidade.

Simplesmente ele não adicionaria nada ao teu token.

Modularizar para uma função ajuda para futuro uso:
```php
    $token = token(100); 
    $token2 = token(100);`
``` 